### PR TITLE
Prepare crates for initial release to crates.io

### DIFF
--- a/capnweb-client/Cargo.toml
+++ b/capnweb-client/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 documentation = "https://docs.rs/capnweb-client"
 description = "High-performance Rust client for Cap'n Web RPC protocol with batching and pipelining"
-readme = "../README.md"
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 
@@ -47,3 +47,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 default = ["all-transports", "macros"]
 all-transports = ["capnweb-transport/default"]
 macros = ["dep:syn", "dep:quote", "dep:proc-macro2"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/capnweb-client/README.md
+++ b/capnweb-client/README.md
@@ -1,0 +1,104 @@
+# capnweb-client
+
+High-performance Rust client for Cap'n Web RPC protocol with batching and pipelining.
+
+## Overview
+
+`capnweb-client` provides a feature-rich client implementation for the Cap'n Web RPC protocol. It supports automatic batching, promise pipelining, capability management, and multiple transport options.
+
+## Features
+
+- **Automatic batching**: Efficiently batch multiple RPC calls
+- **Promise pipelining**: Chain operations without waiting for intermediate results
+- **Multiple transports**: HTTP, WebSocket, and WebTransport support
+- **Connection pooling**: Reuse connections for better performance
+- **Retry logic**: Automatic retry with exponential backoff
+- **Type-safe API**: Strongly-typed client interface
+
+## Usage
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+capnweb-client = "0.1.0"
+```
+
+Basic client usage:
+
+```rust
+use capnweb_client::{Client, ClientConfig};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Create client with configuration
+    let config = ClientConfig {
+        url: "http://localhost:8080/rpc/batch".to_string(),
+        batch_size: 10,
+        batch_timeout_ms: 100,
+        ..Default::default()
+    };
+
+    let client = Client::new(config)?;
+
+    // Make RPC calls
+    let result = client
+        .call("calculator", "add", vec![json!(5), json!(3)])
+        .await?;
+
+    println!("Result: {}", result);
+
+    // Batch multiple calls
+    let batch = client.batch();
+    let future1 = batch.call("service1", "method1", vec![]);
+    let future2 = batch.call("service2", "method2", vec![]);
+    batch.execute().await?;
+
+    let result1 = future1.await?;
+    let result2 = future2.await?;
+
+    Ok(())
+}
+```
+
+## Advanced Features
+
+### Promise Pipelining
+
+```rust
+// Chain operations on promises
+let promise = client.call("service", "getUser", vec![json!(123)]);
+let email_promise = promise.pipeline("getEmail", vec![]);
+let email = email_promise.await?;
+```
+
+### Connection Management
+
+```rust
+// Use WebSocket for real-time communication
+let ws_client = Client::websocket("ws://localhost:8080/rpc/ws").await?;
+
+// Subscribe to events
+ws_client.subscribe("events", |event| {
+    println!("Received event: {:?}", event);
+}).await?;
+```
+
+## Configuration Options
+
+- `url`: Server endpoint URL
+- `batch_size`: Maximum batch size
+- `batch_timeout_ms`: Batch window timeout
+- `connection_timeout_ms`: Connection timeout
+- `retry_count`: Number of retries on failure
+- `retry_delay_ms`: Initial retry delay
+
+## License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.

--- a/capnweb-client/README.md
+++ b/capnweb-client/README.md
@@ -29,6 +29,7 @@ Basic client usage:
 ```rust
 use capnweb_client::{Client, ClientConfig};
 use serde_json::json;
+use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -98,7 +99,7 @@ ws_client.subscribe("events", |event| {
 
 This project is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](../LICENSE-MIT) or https://opensource.org/licenses/MIT)
+ * Apache License, Version 2.0, ([LICENSE-APACHE](https://github.com/currentspace/capn-rs/blob/main/LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](https://github.com/currentspace/capn-rs/blob/main/LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.

--- a/capnweb-core/Cargo.toml
+++ b/capnweb-core/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 documentation = "https://docs.rs/capnweb-core"
 description = "Core protocol implementation for Cap'n Web RPC - capability-based security with promise pipelining"
-readme = "../README.md"
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 
@@ -46,4 +46,8 @@ uuid = { workspace = true, features = ["v4"] }
 default = ["validation"]
 validation = ["dep:jsonschema", "dep:schemars"]
 simd = ["dep:simd-json"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 

--- a/capnweb-core/README.md
+++ b/capnweb-core/README.md
@@ -1,0 +1,66 @@
+# capnweb-core
+
+Core protocol implementation for Cap'n Web RPC - capability-based security with promise pipelining.
+
+## Overview
+
+`capnweb-core` provides the foundational types and protocol implementation for the Cap'n Web RPC system. It includes:
+
+- Wire protocol types (Messages, Calls, Results, Errors)
+- Capability ID management
+- Session and connection handling
+- Protocol validation and error handling
+- Intermediate Language (IL) for complex operations
+
+## Features
+
+- **Capability-based security**: Unforgeable references with explicit lifetime management
+- **Promise pipelining**: Chain operations on results before they complete
+- **Type-safe IDs**: Strongly-typed identifiers for capabilities, calls, and sessions
+- **Structured errors**: Rich error model with proper context propagation
+- **Optional validation**: Schema validation support via feature flag
+
+## Usage
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+capnweb-core = "0.1.0"
+```
+
+Basic usage:
+
+```rust
+use capnweb_core::{CapId, Message, RpcError};
+
+// Create a capability ID
+let cap_id = CapId::new(1);
+
+// Handle protocol messages
+match message {
+    Message::Call { target, method, args, .. } => {
+        // Process RPC call
+    }
+    Message::Result { value, .. } => {
+        // Handle result
+    }
+    Message::Error { error, .. } => {
+        // Handle error
+    }
+}
+```
+
+## Feature Flags
+
+- `validation` (default): Enable JSON schema validation
+- `simd`: Use SIMD-accelerated JSON parsing
+
+## License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.

--- a/capnweb-core/README.md
+++ b/capnweb-core/README.md
@@ -32,21 +32,33 @@ capnweb-core = "0.1.0"
 Basic usage:
 
 ```rust
-use capnweb_core::{CapId, Message, RpcError};
+use capnweb_core::{CapId, Message, CallId, RpcError};
+use serde_json::json;
 
 // Create a capability ID
 let cap_id = CapId::new(1);
+
+// Example: create a message
+let message = Message::Call {
+    id: CallId::new(1),
+    target: cap_id,
+    method: "echo".to_string(),
+    args: vec![json!("hello")],
+};
 
 // Handle protocol messages
 match message {
     Message::Call { target, method, args, .. } => {
         // Process RPC call
+        println!("Call to {}: {}", target, method);
     }
     Message::Result { value, .. } => {
         // Handle result
+        println!("Result: {:?}", value);
     }
     Message::Error { error, .. } => {
         // Handle error
+        println!("Error: {}", error);
     }
 }
 ```

--- a/capnweb-core/README.md
+++ b/capnweb-core/README.md
@@ -60,7 +60,7 @@ match message {
 
 This project is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](../LICENSE-MIT) or https://opensource.org/licenses/MIT)
+ * Apache License, Version 2.0, ([LICENSE-APACHE](https://github.com/currentspace/capn-rs/blob/main/LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](https://github.com/currentspace/capn-rs/blob/main/LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.

--- a/capnweb-server/Cargo.toml
+++ b/capnweb-server/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 documentation = "https://docs.rs/capnweb-server"
 description = "Production-ready server for Cap'n Web RPC protocol with capability management"
-readme = "../README.md"
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 
@@ -67,3 +67,7 @@ tracing-subscriber.workspace = true
 default = ["all-transports"]
 all-transports = ["capnweb-transport/default"]
 h3-server = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:rustls", "dep:rcgen", "dep:http"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/capnweb-server/README.md
+++ b/capnweb-server/README.md
@@ -30,7 +30,9 @@ Create a simple server:
 use capnweb_server::{Server, ServerConfig, RpcTarget};
 use capnweb_core::{CapId, RpcError};
 use async_trait::async_trait;
-use serde_json::Value;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use anyhow::Result;
 
 #[derive(Debug)]
 struct MyService;
@@ -84,7 +86,7 @@ The server can be configured via `ServerConfig`:
 
 This project is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](../LICENSE-MIT) or https://opensource.org/licenses/MIT)
+ * Apache License, Version 2.0, ([LICENSE-APACHE](https://github.com/currentspace/capn-rs/blob/main/LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](https://github.com/currentspace/capn-rs/blob/main/LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.

--- a/capnweb-server/README.md
+++ b/capnweb-server/README.md
@@ -1,0 +1,90 @@
+# capnweb-server
+
+Production-ready server for Cap'n Web RPC protocol with capability management.
+
+## Overview
+
+`capnweb-server` provides a high-performance, production-ready server implementation of the Cap'n Web RPC protocol. It supports multiple transport layers and includes built-in capability management, rate limiting, and observability.
+
+## Features
+
+- **Multiple transports**: HTTP batch, WebSocket, and WebTransport support
+- **Capability management**: Register and manage RPC capabilities
+- **Rate limiting**: Built-in rate limiting and DOS protection
+- **Session management**: Automatic session tracking and cleanup
+- **Observability**: Structured logging and metrics
+- **Type-safe handlers**: Async trait-based RPC target implementation
+
+## Quick Start
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+capnweb-server = "0.1.0"
+```
+
+Create a simple server:
+
+```rust
+use capnweb_server::{Server, ServerConfig, RpcTarget};
+use capnweb_core::{CapId, RpcError};
+use async_trait::async_trait;
+use serde_json::Value;
+
+#[derive(Debug)]
+struct MyService;
+
+#[async_trait]
+impl RpcTarget for MyService {
+    async fn call(&self, method: &str, args: Vec<Value>) -> Result<Value, RpcError> {
+        match method {
+            "echo" => Ok(json!({ "echoed": args })),
+            _ => Err(RpcError::not_found("Method not found")),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let config = ServerConfig {
+        port: 8080,
+        host: "127.0.0.1".to_string(),
+        max_batch_size: 100,
+    };
+
+    let server = Server::new(config);
+    server.register_capability(CapId::new(0), Arc::new(MyService));
+
+    server.run().await?;
+    Ok(())
+}
+```
+
+## Binary
+
+The crate includes a `capnweb-server` binary for quick testing:
+
+```bash
+cargo install capnweb-server
+capnweb-server
+```
+
+## Configuration
+
+The server can be configured via `ServerConfig`:
+
+- `port`: Server port (default: 8080)
+- `host`: Bind address (default: "127.0.0.1")
+- `max_batch_size`: Maximum batch request size
+- `rate_limit`: Requests per second limit
+- `session_timeout`: Session inactivity timeout
+
+## License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.

--- a/capnweb-transport/Cargo.toml
+++ b/capnweb-transport/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 documentation = "https://docs.rs/capnweb-transport"
 description = "Transport layer implementations for Cap'n Web protocol (HTTP, WebSocket, WebTransport)"
-readme = "../README.md"
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 
@@ -52,3 +52,7 @@ websocket = ["dep:tokio-tungstenite", "dep:tungstenite"]
 webtransport = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:rustls", "dep:rustls-pemfile"]
 # http3 = ["dep:quinn", "dep:rustls", "dep:rustls-pemfile"]  # Disabled: experimental, needs update
 http-batch = ["dep:hyper", "dep:tower"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/capnweb-transport/README.md
+++ b/capnweb-transport/README.md
@@ -34,12 +34,12 @@ use capnweb_transport::{Transport, HttpBatchTransport, WebSocketTransport};
 use capnweb_core::Message;
 
 // HTTP Batch transport
-let http_transport = HttpBatchTransport::new("http://localhost:8080/rpc/batch");
+let transport = HttpBatchTransport::new("http://localhost:8080/rpc/batch");
+transport.send(message).await?;
+let response = transport.receive().await?;
 
-// WebSocket transport
-let ws_transport = WebSocketTransport::connect("ws://localhost:8080/rpc/ws").await?;
-
-// Send messages
+// Or use WebSocket transport
+let transport = WebSocketTransport::connect("ws://localhost:8080/rpc/ws").await?;
 transport.send(message).await?;
 let response = transport.receive().await?;
 ```
@@ -62,7 +62,7 @@ Choose your transport based on your needs:
 
 This project is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](../LICENSE-MIT) or https://opensource.org/licenses/MIT)
+ * Apache License, Version 2.0, ([LICENSE-APACHE](https://github.com/currentspace/capn-rs/blob/main/LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](https://github.com/currentspace/capn-rs/blob/main/LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.

--- a/capnweb-transport/README.md
+++ b/capnweb-transport/README.md
@@ -31,11 +31,20 @@ Using different transports:
 
 ```rust
 use capnweb_transport::{Transport, HttpBatchTransport, WebSocketTransport};
-use capnweb_core::Message;
+use capnweb_core::{Message, CallId, CapId};
+use serde_json::json;
+
+// Create a message to send
+let message = Message::Call {
+    id: CallId::new(1),
+    target: CapId::new(0),
+    method: "echo".to_string(),
+    args: vec![json!("hello world")],
+};
 
 // HTTP Batch transport
 let transport = HttpBatchTransport::new("http://localhost:8080/rpc/batch");
-transport.send(message).await?;
+transport.send(message.clone()).await?;
 let response = transport.receive().await?;
 
 // Or use WebSocket transport

--- a/capnweb-transport/README.md
+++ b/capnweb-transport/README.md
@@ -1,0 +1,68 @@
+# capnweb-transport
+
+Transport layer implementations for Cap'n Web protocol (HTTP, WebSocket, WebTransport).
+
+## Overview
+
+`capnweb-transport` provides multiple transport implementations for the Cap'n Web RPC protocol:
+
+- **HTTP Batch**: Traditional request/response with batching support
+- **WebSocket**: Full-duplex streaming with multiplexing
+- **WebTransport**: Modern HTTP/3-based transport with stream multiplexing
+
+## Features
+
+- Pluggable transport abstraction
+- Automatic reconnection and error recovery
+- Message framing and buffering
+- Backpressure handling
+- Connection pooling (HTTP)
+
+## Usage
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+capnweb-transport = "0.1.0"
+```
+
+Using different transports:
+
+```rust
+use capnweb_transport::{Transport, HttpBatchTransport, WebSocketTransport};
+use capnweb_core::Message;
+
+// HTTP Batch transport
+let http_transport = HttpBatchTransport::new("http://localhost:8080/rpc/batch");
+
+// WebSocket transport
+let ws_transport = WebSocketTransport::connect("ws://localhost:8080/rpc/ws").await?;
+
+// Send messages
+transport.send(message).await?;
+let response = transport.receive().await?;
+```
+
+## Feature Flags
+
+- `websocket` (default): WebSocket transport support
+- `http-batch` (default): HTTP batch transport support
+- `webtransport`: WebTransport/HTTP3 support (experimental)
+
+## Transport Selection
+
+Choose your transport based on your needs:
+
+- **HTTP Batch**: Simple, firewall-friendly, works everywhere
+- **WebSocket**: Real-time updates, lower latency, persistent connection
+- **WebTransport**: Best performance, multiplexing, requires HTTP/3
+
+## License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.


### PR DESCRIPTION
## Summary
This PR prepares all Cap'n Web crates for their initial release to crates.io and ensures documentation will build properly on docs.rs.

## Changes
- ✅ Created README.md files for each crate with usage examples and feature documentation
- ✅ Added docs.rs metadata to all Cargo.toml files for optimal documentation generation
- ✅ Updated readme paths in Cargo.toml to point to crate-specific READMEs
- ✅ Verified all required package metadata is present

## Testing
- ✅ `cargo build --workspace --all-features` passes
- ✅ `cargo doc --workspace --no-deps --all-features` generates documentation successfully
- ✅ `cargo publish --dry-run` succeeds for capnweb-core (other crates depend on it being published first)

## Publishing Order
Crates must be published in this order due to dependencies:
1. **capnweb-core** - No internal dependencies ✅ Ready
2. **capnweb-transport** - Depends on capnweb-core
3. **capnweb-server** - Depends on capnweb-core and capnweb-transport
4. **capnweb-client** - Depends on capnweb-core and capnweb-transport

## Next Steps
After merging this PR:
1. Set up `CARGO_REGISTRY_TOKEN` secret in repository settings
2. Create a release tag (e.g., `v0.1.0`)
3. Either manually publish crates or set up GitHub Actions workflow for automated publishing

## Related Issues
- Fixes #12 (Publish Cap'n Web crates to crates.io)
- Fixes #13 (Publish Cap'n Web documentation to docs.rs)

## Documentation Preview
Once published, documentation will be available at:
- https://docs.rs/capnweb-core
- https://docs.rs/capnweb-transport
- https://docs.rs/capnweb-server
- https://docs.rs/capnweb-client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added comprehensive READMEs for client, core, server, and transport crates with overviews, features, quick starts, usage examples, configuration, advanced topics, and licensing.
- Chores
  - Updated package metadata to use local README files and enabled docs.rs to build with all features and docsrs rustdoc args.
  - Minor formatting tweaks in package metadata sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->