### PR TITLE
Fix release workflow to support workspace versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,24 @@ jobs:
       - name: Verify version in Cargo.toml
         run: |
           VERSION=${{ steps.version.outputs.version }}
+
+          # Check workspace version
+          WORKSPACE_VERSION=$(grep "^version" Cargo.toml | head -1 | cut -d'"' -f2)
+          if [[ "$WORKSPACE_VERSION" != "$VERSION" ]]; then
+            echo "Version mismatch in workspace: expected $VERSION, found $WORKSPACE_VERSION"
+            exit 1
+          fi
+
+          # Verify crates are using workspace version
           for crate in capnweb-core capnweb-transport capnweb-server capnweb-client; do
-            CARGO_VERSION=$(grep "^version" $crate/Cargo.toml | head -1 | cut -d'"' -f2)
-            if [[ "$CARGO_VERSION" != "$VERSION" ]]; then
-              echo "Version mismatch in $crate: expected $VERSION, found $CARGO_VERSION"
-              exit 1
+            if grep -q "^version.workspace = true" $crate/Cargo.toml; then
+              echo "✓ $crate uses workspace version"
+            else
+              CARGO_VERSION=$(grep "^version" $crate/Cargo.toml | head -1 | cut -d'"' -f2)
+              if [[ "$CARGO_VERSION" != "$VERSION" ]]; then
+                echo "Version mismatch in $crate: expected $VERSION, found $CARGO_VERSION"
+                exit 1
+              fi
             fi
           done
 


### PR DESCRIPTION
## Problem
The release workflow fails when trying to publish v0.1.0 because it doesn't understand Cargo workspace version inheritance.

## Solution
Updated the version verification step in the release workflow to:
1. Check the workspace-level version in root Cargo.toml
2. Verify that each crate either uses `version.workspace = true` OR has the correct explicit version
3. Support both patterns properly

## Why Workspace Versions Are Better
Using `version.workspace = true` in each crate:
- Ensures all crates have the same version
- Single source of truth for versioning
- Easier to manage releases
- Cargo automatically resolves these when publishing to crates.io

## Testing
The updated workflow will now correctly verify versions and proceed with the release when the tag v0.1.0 is pushed.

Fixes the release workflow failure from run #18109926753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enhanced release workflow with a workspace-wide version consistency check to prevent mismatched versions during releases.
  - Improved handling of per-crate versions: automatically recognizes crates inheriting the workspace version and skips redundant comparisons.
  - Maintains strict validation for crates with explicit versions, failing the release if any mismatch is detected.
  - Adds clearer release-time messaging to indicate when workspace-inherited versions are used versus when per-crate validation is performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->