### PR TITLE
Rename crates to currentspace-capnweb-* prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Check for banned dependencies
         run: |
-          if cargo tree -p capnweb-core | grep -E "(openssl|native-tls)"; then
+          if cargo tree -p currentspace-capnweb-core | grep -E "(openssl|native-tls)"; then
             echo "Found banned dependencies (openssl/native-tls). Use rustls instead."
             exit 1
           fi
@@ -258,16 +258,16 @@ jobs:
       #   continue-on-error: true  # Don't fail on first release
 
       - name: Check capnweb-core manifest
-        run: cargo check --package capnweb-core --no-default-features
+        run: cargo check --package currentspace-capnweb-core --no-default-features
 
       - name: Check capnweb-transport manifest
-        run: cargo check --package capnweb-transport --no-default-features
+        run: cargo check --package currentspace-capnweb-transport --no-default-features
 
       - name: Check capnweb-server manifest
-        run: cargo check --package capnweb-server --no-default-features
+        run: cargo check --package currentspace-capnweb-server --no-default-features
 
       - name: Check capnweb-client manifest
-        run: cargo check --package capnweb-client --no-default-features
+        run: cargo check --package currentspace-capnweb-client --no-default-features
 
   benchmark:
     name: Benchmarks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,7 +83,7 @@ jobs:
               <meta charset="UTF-8">
               <meta name="viewport" content="width=device-width, initial-scale=1.0">
               <title>Cap'n Web Rust Documentation</title>
-              <meta http-equiv="refresh" content="0; url=capnweb_core/index.html">
+              <meta http-equiv="refresh" content="0; url=currentspace_capnweb_core/index.html">
               <style>
                   body {
                       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -132,7 +132,7 @@ jobs:
 
               <div class="auto-redirect">
                   <strong>Auto-redirecting to currentspace-capnweb-core documentation...</strong><br>
-                  If not redirected, <a href="capnweb_core/index.html">click here</a>.
+                  If not redirected, <a href="currentspace_capnweb_core/index.html">click here</a>.
               </div>
 
               <p>A complete, production-ready implementation of the Cap'n Web protocol in Rust,
@@ -140,27 +140,27 @@ jobs:
 
               <div class="crates">
                   <div class="crate">
-                      <h2><a href="capnweb_core/index.html">currentspace-capnweb-core</a></h2>
+                      <h2><a href="currentspace_capnweb_core/index.html">currentspace-capnweb-core</a></h2>
                       <p>Core protocol implementation including messages, IL, and validation.</p>
                   </div>
 
                   <div class="crate">
-                      <h2><a href="capnweb_transport/index.html">currentspace-capnweb-transport</a></h2>
+                      <h2><a href="currentspace_capnweb_transport/index.html">currentspace-capnweb-transport</a></h2>
                       <p>Transport layer implementations for HTTP, WebSocket, and WebTransport.</p>
                   </div>
 
                   <div class="crate">
-                      <h2><a href="capnweb_server/index.html">currentspace-capnweb-server</a></h2>
+                      <h2><a href="currentspace_capnweb_server/index.html">currentspace-capnweb-server</a></h2>
                       <p>Server implementation with capability management and lifecycle.</p>
                   </div>
 
                   <div class="crate">
-                      <h2><a href="capnweb_client/index.html">currentspace-capnweb-client</a></h2>
+                      <h2><a href="currentspace_capnweb_client/index.html">currentspace-capnweb-client</a></h2>
                       <p>Client implementation with ergonomic recorder API.</p>
                   </div>
 
                   <div class="crate">
-                      <h2><a href="capnweb_interop_tests/index.html">currentspace-capnweb-interop-tests</a></h2>
+                      <h2><a href="currentspace_capnweb_interop_tests/index.html">currentspace-capnweb-interop-tests</a></h2>
                       <p>JavaScript interoperability verification tests.</p>
                   </div>
               </div>
@@ -270,10 +270,10 @@ jobs:
         run: |
           echo "Documentation deployed to: ${{ steps.deployment.outputs.page_url }}"
           echo "Direct links:"
-          echo "  - Core: ${{ steps.deployment.outputs.page_url }}capnweb_core/index.html"
-          echo "  - Transport: ${{ steps.deployment.outputs.page_url }}capnweb_transport/index.html"
-          echo "  - Server: ${{ steps.deployment.outputs.page_url }}capnweb_server/index.html"
-          echo "  - Client: ${{ steps.deployment.outputs.page_url }}capnweb_client/index.html"
+          echo "  - Core: ${{ steps.deployment.outputs.page_url }}currentspace_capnweb_core/index.html"
+          echo "  - Transport: ${{ steps.deployment.outputs.page_url }}currentspace_capnweb_transport/index.html"
+          echo "  - Server: ${{ steps.deployment.outputs.page_url }}currentspace_capnweb_server/index.html"
+          echo "  - Client: ${{ steps.deployment.outputs.page_url }}currentspace_capnweb_client/index.html"
 
   pr-comment:
     name: Add PR Comment with Documentation Preview

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -131,7 +131,7 @@ jobs:
               <h1>🚀 Cap'n Web Rust Implementation</h1>
 
               <div class="auto-redirect">
-                  <strong>Auto-redirecting to capnweb-core documentation...</strong><br>
+                  <strong>Auto-redirecting to currentspace-capnweb-core documentation...</strong><br>
                   If not redirected, <a href="capnweb_core/index.html">click here</a>.
               </div>
 
@@ -140,27 +140,27 @@ jobs:
 
               <div class="crates">
                   <div class="crate">
-                      <h2><a href="capnweb_core/index.html">capnweb-core</a></h2>
+                      <h2><a href="capnweb_core/index.html">currentspace-capnweb-core</a></h2>
                       <p>Core protocol implementation including messages, IL, and validation.</p>
                   </div>
 
                   <div class="crate">
-                      <h2><a href="capnweb_transport/index.html">capnweb-transport</a></h2>
+                      <h2><a href="capnweb_transport/index.html">currentspace-capnweb-transport</a></h2>
                       <p>Transport layer implementations for HTTP, WebSocket, and WebTransport.</p>
                   </div>
 
                   <div class="crate">
-                      <h2><a href="capnweb_server/index.html">capnweb-server</a></h2>
+                      <h2><a href="capnweb_server/index.html">currentspace-capnweb-server</a></h2>
                       <p>Server implementation with capability management and lifecycle.</p>
                   </div>
 
                   <div class="crate">
-                      <h2><a href="capnweb_client/index.html">capnweb-client</a></h2>
+                      <h2><a href="capnweb_client/index.html">currentspace-capnweb-client</a></h2>
                       <p>Client implementation with ergonomic recorder API.</p>
                   </div>
 
                   <div class="crate">
-                      <h2><a href="capnweb_interop_tests/index.html">capnweb-interop-tests</a></h2>
+                      <h2><a href="capnweb_interop_tests/index.html">currentspace-capnweb-interop-tests</a></h2>
                       <p>JavaScript interoperability verification tests.</p>
                   </div>
               </div>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,25 +160,25 @@ jobs:
         run: |
           cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Publish capnweb-core
+      - name: Publish currentspace-capnweb-core
         run: |
           cd capnweb-core
           cargo publish --no-verify
           sleep 10  # Wait for crates.io to index
 
-      - name: Publish capnweb-transport
+      - name: Publish currentspace-capnweb-transport
         run: |
           cd capnweb-transport
           cargo publish --no-verify
           sleep 10
 
-      - name: Publish capnweb-server
+      - name: Publish currentspace-capnweb-server
         run: |
           cd capnweb-server
           cargo publish --no-verify
           sleep 10
 
-      - name: Publish capnweb-client
+      - name: Publish currentspace-capnweb-client
         run: |
           cd capnweb-client
           cargo publish --no-verify
@@ -220,13 +220,13 @@ jobs:
           echo "" >> RELEASE_NOTES.md
           echo '```toml' >> RELEASE_NOTES.md
           echo "[dependencies]" >> RELEASE_NOTES.md
-          echo "capnweb-server = \"$VERSION\"" >> RELEASE_NOTES.md
-          echo "capnweb-client = \"$VERSION\"" >> RELEASE_NOTES.md
+          echo "currentspace-capnweb-server = \"$VERSION\"" >> RELEASE_NOTES.md
+          echo "currentspace-capnweb-client = \"$VERSION\"" >> RELEASE_NOTES.md
           echo '```' >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
           echo "## Documentation" >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
-          echo "- [API Documentation](https://docs.rs/capnweb-core/$VERSION)" >> RELEASE_NOTES.md
+          echo "- [API Documentation](https://docs.rs/currentspace-capnweb-core/$VERSION)" >> RELEASE_NOTES.md
           echo "- [Examples](https://github.com/currentspace/capn-rs/tree/v$VERSION/examples)" >> RELEASE_NOTES.md
 
       - name: Create Release
@@ -276,4 +276,4 @@ jobs:
           VERSION=${{ needs.verify.outputs.version }}
           echo "🎉 Cap'n Web Rust v$VERSION has been released!"
           echo "View the release: https://github.com/currentspace/capn-rs/releases/tag/v$VERSION"
-          echo "Crates.io: https://crates.io/crates/capnweb-core"
+          echo "Crates.io: https://crates.io/crates/currentspace-capnweb-core"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,7 +255,7 @@ jobs:
       - name: Build documentation
         run: |
           cargo +nightly doc --workspace --no-deps --all-features
-          echo '<meta http-equiv="refresh" content="0; url=capnweb_core/index.html">' > target/doc/index.html
+          echo '<meta http-equiv="refresh" content="0; url=currentspace_capnweb_core/index.html">' > target/doc/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ git push
 - **Test execution**:
   ```bash
   # Run tests for specific crate
-  cargo test -p capnweb-core
+  cargo test -p currentspace-capnweb-core
 
   # Run all tests
   cargo test --workspace
@@ -102,11 +102,11 @@ git push
 #### Crate Structure
 ```
 capnweb-rs/
-  capnweb-core/        # Protocol types, wire format
-  capnweb-transport/   # Transport abstractions
-  capnweb-server/      # Server implementation
-  capnweb-client/      # Client implementation
-  capnweb-interop-tests/ # Cross-language tests
+  capnweb-core/        # Protocol types, wire format (crate: currentspace-capnweb-core)
+  capnweb-transport/   # Transport abstractions (crate: currentspace-capnweb-transport)
+  capnweb-server/      # Server implementation (crate: currentspace-capnweb-server)
+  capnweb-client/      # Client implementation (crate: currentspace-capnweb-client)
+  capnweb-interop-tests/ # Cross-language tests (crate: currentspace-capnweb-interop-tests)
 ```
 
 #### Module Patterns
@@ -188,7 +188,7 @@ mod tests {
 cargo build --workspace
 
 # Build specific crate
-cargo build -p capnweb-core
+cargo build -p currentspace-capnweb-core
 
 # Run the server binary
 cargo run --bin capnweb-server
@@ -203,7 +203,7 @@ cargo build --features webtransport
 cargo test --workspace
 
 # Run specific crate tests
-cargo test -p capnweb-server
+cargo test -p currentspace-capnweb-server
 
 # Run with output for debugging
 cargo test -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/currentspace/capn-rs"
 homepage = "https://github.com/currentspace/capn-rs"
-documentation = "https://docs.rs/capnweb-core"
+documentation = "https://docs.rs/currentspace-capnweb-core"
 readme = "README.md"
 keywords = ["rpc", "capnweb", "capability", "protocol", "async"]
 categories = ["network-programming", "web-programming", "asynchronous"]
@@ -114,10 +114,10 @@ insta = "1.41"
 chrono = { version = "0.4", features = ["serde"] }
 
 # Internal crates
-capnweb-core = { version = "0.1.0", path = "capnweb-core" }
-capnweb-transport = { version = "0.1.0", path = "capnweb-transport" }
-capnweb-server = { version = "0.1.0", path = "capnweb-server" }
-capnweb-client = { version = "0.1.0", path = "capnweb-client" }
+currentspace-capnweb-core = { version = "0.1.0", path = "capnweb-core" }
+currentspace-capnweb-transport = { version = "0.1.0", path = "capnweb-transport" }
+currentspace-capnweb-server = { version = "0.1.0", path = "capnweb-server" }
+currentspace-capnweb-client = { version = "0.1.0", path = "capnweb-client" }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -310,10 +310,10 @@ at your option.
 ### 📚 Online Documentation
 
 - **[API Documentation (GitHub Pages)](https://currentspace.github.io/capn-rs/)** - Full API documentation for all crates
-  - [currentspace-capnweb-core](https://currentspace.github.io/capn-rs/capnweb_core/) - Core protocol types and messages
-  - [currentspace-capnweb-transport](https://currentspace.github.io/capn-rs/capnweb_transport/) - Transport implementations
-  - [currentspace-capnweb-server](https://currentspace.github.io/capn-rs/capnweb_server/) - Server capabilities
-  - [currentspace-capnweb-client](https://currentspace.github.io/capn-rs/capnweb_client/) - Client implementation
+  - [currentspace-capnweb-core](https://currentspace.github.io/capn-rs/currentspace_capnweb_core/) - Core protocol types and messages
+  - [currentspace-capnweb-transport](https://currentspace.github.io/capn-rs/currentspace_capnweb_transport/) - Transport implementations
+  - [currentspace-capnweb-server](https://currentspace.github.io/capn-rs/currentspace_capnweb_server/) - Server capabilities
+  - [currentspace-capnweb-client](https://currentspace.github.io/capn-rs/currentspace_capnweb_client/) - Client implementation
 
 - **[docs.rs](https://docs.rs/currentspace-capnweb-core)** - Published crate documentation:
   - [currentspace-capnweb-core](https://docs.rs/currentspace-capnweb-core/0.1.0) - Core protocol types

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A complete, production-ready implementation of the [Cap'n Web](https://github.co
 [![CI](https://github.com/currentspace/capn-rs/workflows/CI/badge.svg)](https://github.com/currentspace/capn-rs/actions/workflows/ci.yml)
 [![Documentation](https://github.com/currentspace/capn-rs/workflows/Documentation/badge.svg)](https://github.com/currentspace/capn-rs/actions/workflows/docs.yml)
 [![TypeScript Interop](https://github.com/currentspace/capn-rs/workflows/TypeScript%20Interop%20Tests/badge.svg)](https://github.com/currentspace/capn-rs/actions/workflows/interop.yml)
-[![docs.rs](https://docs.rs/capnweb-core/badge.svg)](https://docs.rs/capnweb-core)
+[![docs.rs](https://docs.rs/currentspace-capnweb-core/badge.svg)](https://docs.rs/currentspace-capnweb-core)
 [![GitHub Pages](https://img.shields.io/badge/docs-github%20pages-blue)](https://currentspace.github.io/capn-rs/)
-[![Crates.io](https://img.shields.io/crates/v/capnweb-core.svg)](https://crates.io/crates/capnweb-core)
-[![License](https://img.shields.io/crates/l/capnweb-core.svg)](https://github.com/currentspace/capn-rs#license)
+[![Crates.io](https://img.shields.io/crates/v/currentspace-capnweb-core.svg)](https://crates.io/crates/currentspace-capnweb-core)
+[![License](https://img.shields.io/crates/l/currentspace-capnweb-core.svg)](https://github.com/currentspace/capn-rs#license)
 [![Rust 1.85+](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
 
 ## Features
@@ -27,15 +27,15 @@ A complete, production-ready implementation of the [Cap'n Web](https://github.co
 
 ```toml
 [dependencies]
-capnweb-server = "0.1.0"
-capnweb-client = "0.1.0"
+currentspace-capnweb-server = "0.1.0"
+currentspace-capnweb-client = "0.1.0"
 ```
 
 ### Server Example
 
 ```rust
-use capnweb_server::{Server, ServerConfig, RpcTarget};
-use capnweb_core::{CapId, RpcError};
+use currentspace_capnweb_server::{Server, ServerConfig, RpcTarget};
+use currentspace_capnweb_core::{CapId, RpcError};
 use serde_json::{json, Value};
 use std::sync::Arc;
 
@@ -72,8 +72,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Client Example
 
 ```rust
-use capnweb_client::{Client, ClientConfig};
-use capnweb_core::CapId;
+use currentspace_capnweb_client::{Client, ClientConfig};
+use currentspace_capnweb_core::CapId;
 use serde_json::json;
 
 #[tokio::main]
@@ -97,17 +97,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 The implementation is organized into focused crates:
 
-- **`capnweb-core`** - Core protocol implementation (messages, IL, validation)
-- **`capnweb-transport`** - Transport layer implementations (HTTP, WebSocket, WebTransport)
-- **`capnweb-server`** - Server implementation with capability management
-- **`capnweb-client`** - Client implementation with ergonomic recorder API
-- **`capnweb-interop-tests`** - JavaScript interoperability verification
+- **`currentspace-capnweb-core`** - Core protocol implementation (messages, IL, validation)
+- **`currentspace-capnweb-transport`** - Transport layer implementations (HTTP, WebSocket, WebTransport)
+- **`currentspace-capnweb-server`** - Server implementation with capability management
+- **`currentspace-capnweb-client`** - Client implementation with ergonomic recorder API
+- **`currentspace-capnweb-interop-tests`** - JavaScript interoperability verification
 
 ## Transport Support
 
 ### HTTP Batch Transport
 ```rust
-use capnweb_client::{Client, ClientConfig};
+use currentspace_capnweb_client::{Client, ClientConfig};
 
 let config = ClientConfig {
     url: "http://localhost:8080/rpc/batch".to_string(),
@@ -120,7 +120,7 @@ let client = Client::new(config)?;
 ```rust
 // WebSocket transport is implemented and available
 // Usage requires creating a WebSocketTransport from an established WebSocket connection
-use capnweb_transport::WebSocketTransport;
+use currentspace_capnweb_transport::WebSocketTransport;
 use tokio_tungstenite::connect_async;
 
 let (ws_stream, _) = connect_async("ws://localhost:8080/ws").await?;
@@ -129,7 +129,7 @@ let transport = WebSocketTransport::new(ws_stream);
 
 ### WebTransport/HTTP3
 ```rust
-use capnweb_server::H3Server;
+use currentspace_capnweb_server::H3Server;
 
 let mut h3_server = H3Server::new(server);
 h3_server.listen("0.0.0.0:8443".parse()?).await?;
@@ -191,8 +191,8 @@ cargo run --example calculator_client
 cargo run --example error_handling
 cargo run --example batch_pipelining
 
-# Start the server (using bin/capnweb-server)
-cargo run --bin capnweb-server
+# Start the server (using bin/currentspace-capnweb-server)
+cargo run --bin currentspace-capnweb-server
 ```
 
 ## Performance
@@ -218,9 +218,9 @@ Comprehensive test suite with tests across all core modules:
 cargo test --workspace
 
 # Run specific crate tests
-cargo test -p capnweb-core
-cargo test -p capnweb-server
-cargo test -p capnweb-client
+cargo test -p currentspace-capnweb-core
+cargo test -p currentspace-capnweb-server
+cargo test -p currentspace-capnweb-client
 
 # Run with output for debugging
 cargo test -- --nocapture
@@ -237,14 +237,14 @@ The Rust implementation is fully compatible with JavaScript Cap'n Web implementa
 
 Test interoperability:
 ```bash
-cargo test --package capnweb-interop-tests
+cargo test --package currentspace-capnweb-interop-tests
 ```
 
 ## Production Deployment
 
 ### Configuration
 ```rust
-use capnweb_server::ServerConfig;
+use currentspace_capnweb_server::ServerConfig;
 
 let config = ServerConfig {
     port: 8080,
@@ -310,16 +310,16 @@ at your option.
 ### 📚 Online Documentation
 
 - **[API Documentation (GitHub Pages)](https://currentspace.github.io/capn-rs/)** - Full API documentation for all crates
-  - [capnweb-core](https://currentspace.github.io/capn-rs/capnweb_core/) - Core protocol types and messages
-  - [capnweb-transport](https://currentspace.github.io/capn-rs/capnweb_transport/) - Transport implementations
-  - [capnweb-server](https://currentspace.github.io/capn-rs/capnweb_server/) - Server capabilities
-  - [capnweb-client](https://currentspace.github.io/capn-rs/capnweb_client/) - Client implementation
+  - [currentspace-capnweb-core](https://currentspace.github.io/capn-rs/capnweb_core/) - Core protocol types and messages
+  - [currentspace-capnweb-transport](https://currentspace.github.io/capn-rs/capnweb_transport/) - Transport implementations
+  - [currentspace-capnweb-server](https://currentspace.github.io/capn-rs/capnweb_server/) - Server capabilities
+  - [currentspace-capnweb-client](https://currentspace.github.io/capn-rs/capnweb_client/) - Client implementation
 
-- **[docs.rs](https://docs.rs/capnweb-core)** - Published crate documentation:
-  - [capnweb-core](https://docs.rs/capnweb-core/0.1.0) - Core protocol types
-  - [capnweb-transport](https://docs.rs/capnweb-transport/0.1.0) - Transport layers
-  - [capnweb-server](https://docs.rs/capnweb-server/0.1.0) - Server implementation
-  - [capnweb-client](https://docs.rs/capnweb-client/0.1.0) - Client library
+- **[docs.rs](https://docs.rs/currentspace-capnweb-core)** - Published crate documentation:
+  - [currentspace-capnweb-core](https://docs.rs/currentspace-capnweb-core/0.1.0) - Core protocol types
+  - [currentspace-capnweb-transport](https://docs.rs/currentspace-capnweb-transport/0.1.0) - Transport layers
+  - [currentspace-capnweb-server](https://docs.rs/currentspace-capnweb-server/0.1.0) - Server implementation
+  - [currentspace-capnweb-client](https://docs.rs/currentspace-capnweb-client/0.1.0) - Client library
 
 ### 📖 Project Documentation
 
@@ -346,7 +346,7 @@ cargo doc --workspace --all-features --no-deps 2>&1 | grep warning
 All public APIs are documented. To check documentation coverage:
 
 ```bash
-cargo rustdoc -p capnweb-core -- -Z unstable-options --show-coverage
+cargo rustdoc -p currentspace-capnweb-core -- -Z unstable-options --show-coverage
 ```
 
 ## Roadmap

--- a/benches/protocol_benchmarks.rs
+++ b/benches/protocol_benchmarks.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
-use capnweb_core::{Plan, Op, Source, CapId, Message, CallId, Target, Outcome};
-use capnweb_client::{Recorder, params};
+use currentspace_capnweb_core::{Plan, Op, Source, CapId, Message, CallId, Target, Outcome};
+use currentspace_capnweb_client::{Recorder, params};
 use serde_json::json;
 use std::collections::BTreeMap;
 
@@ -149,7 +149,7 @@ fn bench_recorder_api(c: &mut Criterion) {
             let user = api.call("getUser", params![123]);
             let name = user.call("getName", vec![]);
 
-            use capnweb_client::record_object;
+            use currentspace_capnweb_client::record_object;
             let result = record_object!(recorder; {
                 "sum" => sum,
                 "userName" => name,

--- a/capnweb-client/Cargo.toml
+++ b/capnweb-client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "capnweb-client"
+name = "currentspace-capnweb-client"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -7,15 +7,15 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation = "https://docs.rs/capnweb-client"
+documentation = "https://docs.rs/currentspace-capnweb-client"
 description = "High-performance Rust client for Cap'n Web RPC protocol with batching and pipelining"
 readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-capnweb-core.workspace = true
-capnweb-transport.workspace = true
+currentspace-capnweb-core.workspace = true
+currentspace-capnweb-transport.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -40,12 +40,12 @@ proc-macro2 = { version = "1.0", optional = true }
 mockito.workspace = true
 proptest.workspace = true
 criterion.workspace = true
-capnweb-server.workspace = true
+currentspace-capnweb-server.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 default = ["all-transports", "macros"]
-all-transports = ["capnweb-transport/default"]
+all-transports = ["currentspace-capnweb-transport/default"]
 macros = ["dep:syn", "dep:quote", "dep:proc-macro2"]
 
 [package.metadata.docs.rs]

--- a/capnweb-client/examples/basic_client.rs
+++ b/capnweb-client/examples/basic_client.rs
@@ -5,8 +5,8 @@
 // - Basic error handling
 
 use anyhow::Result;
-use capnweb_client::{Client, ClientConfig};
-use capnweb_core::CapId;
+use currentspace_capnweb_client::{Client, ClientConfig};
+use currentspace_capnweb_core::CapId;
 use serde_json::json;
 use tracing::info;
 

--- a/capnweb-client/examples/batch_pipelining.rs
+++ b/capnweb-client/examples/batch_pipelining.rs
@@ -5,8 +5,8 @@
 // Mirrors the functionality of TypeScript's batch-pipelining/client.mjs
 
 use anyhow::Result;
-use capnweb_client::{Client, ClientConfig};
-use capnweb_core::CapId;
+use currentspace_capnweb_client::{Client, ClientConfig};
+use currentspace_capnweb_core::CapId;
 use serde_json::{json, Value};
 use std::time::Instant;
 use tracing::info;

--- a/capnweb-client/examples/calculator_client.rs
+++ b/capnweb-client/examples/calculator_client.rs
@@ -5,8 +5,8 @@
 // - Error handling for division by zero
 
 use anyhow::Result;
-use capnweb_client::{Client, ClientConfig};
-use capnweb_core::CapId;
+use currentspace_capnweb_client::{Client, ClientConfig};
+use currentspace_capnweb_core::CapId;
 use serde_json::json;
 use tracing::info;
 

--- a/capnweb-client/examples/error_handling.rs
+++ b/capnweb-client/examples/error_handling.rs
@@ -7,8 +7,8 @@
 // - Timeout handling
 
 use anyhow::Result;
-use capnweb_client::{Client, ClientConfig};
-use capnweb_core::CapId;
+use currentspace_capnweb_client::{Client, ClientConfig};
+use currentspace_capnweb_core::CapId;
 use serde_json::json;
 use tracing::info;
 

--- a/capnweb-client/src/client.rs
+++ b/capnweb-client/src/client.rs
@@ -6,7 +6,7 @@
 // - Error handling and validation
 
 use anyhow::{Context, Result};
-use capnweb_core::CapId;
+use currentspace_capnweb_core::CapId;
 use reqwest::Client as HttpClient;
 use serde_json::{json, Value};
 use std::collections::HashMap;

--- a/capnweb-client/src/lib.rs
+++ b/capnweb-client/src/lib.rs
@@ -11,8 +11,8 @@
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use capnweb_client::{Client, ClientConfig};
-//! use capnweb_core::CapId;
+//! use currentspace_capnweb_client::{Client, ClientConfig};
+//! use currentspace_capnweb_core::CapId;
 //! use serde_json::json;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -36,8 +36,8 @@
 //! Batch multiple operations for efficient network usage:
 //!
 //! ```rust,no_run
-//! use capnweb_client::Client;
-//! use capnweb_core::CapId;
+//! use currentspace_capnweb_client::Client;
+//! use currentspace_capnweb_core::CapId;
 //! use serde_json::json;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -63,8 +63,8 @@
 //! Chain operations on unresolved promises to minimize latency:
 //!
 //! ```rust,no_run
-//! use capnweb_client::Client;
-//! use capnweb_core::CapId;
+//! use currentspace_capnweb_client::Client;
+//! use currentspace_capnweb_core::CapId;
 //! use serde_json::json;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/capnweb-client/src/macros.rs
+++ b/capnweb-client/src/macros.rs
@@ -5,7 +5,7 @@
 /// # Example
 ///
 /// ```rust
-/// use capnweb_client::params;
+/// use currentspace_capnweb_client::params;
 /// let args = params![5, "hello", true];
 /// ```
 #[macro_export]
@@ -22,8 +22,8 @@ macro_rules! params {
 /// # Example
 ///
 /// ```rust
-/// use capnweb_client::{record_object, Recorder};
-/// use capnweb_core::CapId;
+/// use currentspace_capnweb_client::{record_object, Recorder};
+/// use currentspace_capnweb_core::CapId;
 /// let recorder = Recorder::new();
 /// let cap = recorder.capture("api", CapId::new(1));
 /// let name_result = cap.call("getName", vec![]);
@@ -49,8 +49,8 @@ macro_rules! record_object {
 /// # Example
 ///
 /// ```rust
-/// use capnweb_client::{record_array, Recorder};
-/// use capnweb_core::CapId;
+/// use currentspace_capnweb_client::{record_array, Recorder};
+/// use currentspace_capnweb_core::CapId;
 /// let recorder = Recorder::new();
 /// let cap = recorder.capture("api", CapId::new(1));
 /// let item1 = cap.call("getValue", vec![]);
@@ -70,8 +70,8 @@ macro_rules! record_array {
 /// # Example
 ///
 /// ```rust
-/// use capnweb_client::{record_plan, Recorder, params};
-/// use capnweb_core::CapId;
+/// use currentspace_capnweb_client::{record_plan, Recorder, params};
+/// use currentspace_capnweb_core::CapId;
 /// let cap_id = CapId::new(1);
 /// let plan = record_plan! {
 ///     {
@@ -92,7 +92,7 @@ macro_rules! record_plan {
 #[cfg(test)]
 mod tests {
     use crate::recorder::Recorder;
-    use capnweb_core::CapId;
+    use currentspace_capnweb_core::CapId;
 
     #[test]
     fn test_params_macro() {

--- a/capnweb-client/src/recorder.rs
+++ b/capnweb-client/src/recorder.rs
@@ -1,4 +1,4 @@
-use capnweb_core::{CapId, Op, Plan, Source};
+use currentspace_capnweb_core::{CapId, Op, Plan, Source};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};

--- a/capnweb-core/Cargo.toml
+++ b/capnweb-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "capnweb-core"
+name = "currentspace-capnweb-core"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -7,7 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation = "https://docs.rs/capnweb-core"
+documentation = "https://docs.rs/currentspace-capnweb-core"
 description = "Core protocol implementation for Cap'n Web RPC - capability-based security with promise pipelining"
 readme = "README.md"
 keywords.workspace = true

--- a/capnweb-core/src/lib.rs
+++ b/capnweb-core/src/lib.rs
@@ -13,7 +13,7 @@
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use capnweb_core::{CapId, RpcTarget, RpcError, Value};
+//! use currentspace_capnweb_core::{CapId, RpcTarget, RpcError, Value};
 //! use async_trait::async_trait;
 //! use serde_json::json;
 //!

--- a/capnweb-core/tests/advanced_features_integration.rs
+++ b/capnweb-core/tests/advanced_features_integration.rs
@@ -254,7 +254,9 @@ impl CapabilityFactory for CalculatorFactory {
                     let mut schema = HashMap::new();
                     schema.insert(
                         "precision".to_string(),
-                        Box::new(currentspace_capnweb_core::protocol::Value::String("number".to_string())),
+                        Box::new(currentspace_capnweb_core::protocol::Value::String(
+                            "number".to_string(),
+                        )),
                     );
                     schema
                 })),
@@ -338,7 +340,9 @@ async fn test_comprehensive_advanced_features_integration() {
         let mut obj = HashMap::new();
         obj.insert(
             "precision".to_string(),
-            Box::new(currentspace_capnweb_core::protocol::Value::Number(Number::from(4))),
+            Box::new(currentspace_capnweb_core::protocol::Value::Number(
+                Number::from(4),
+            )),
         );
         obj
     });
@@ -430,7 +434,8 @@ async fn test_comprehensive_advanced_features_integration() {
 
             // Verify the calculation: (5 + 3) * 2 = 16
             if let Some(boxed_final) = obj.get("final_result") {
-                if let currentspace_capnweb_core::protocol::Value::Number(n) = boxed_final.as_ref() {
+                if let currentspace_capnweb_core::protocol::Value::Number(n) = boxed_final.as_ref()
+                {
                     assert_eq!(n.as_f64(), Some(16.0), "Calculation result should be 16");
                     println!("✅ Calculation result verified: {}", n);
                 }
@@ -489,7 +494,9 @@ async fn test_comprehensive_advanced_features_integration() {
         let mut obj = HashMap::new();
         obj.insert(
             "precision".to_string(),
-            Box::new(currentspace_capnweb_core::protocol::Value::Number(Number::from(6))),
+            Box::new(currentspace_capnweb_core::protocol::Value::Number(
+                Number::from(6),
+            )),
         );
         obj
     });
@@ -527,7 +534,10 @@ async fn test_comprehensive_advanced_features_integration() {
 
     // Test capability factory error handling
     let bad_capability = factory
-        .create_capability("nonexistent", currentspace_capnweb_core::protocol::Value::Null)
+        .create_capability(
+            "nonexistent",
+            currentspace_capnweb_core::protocol::Value::Null,
+        )
         .await;
     assert!(
         bad_capability.is_err(),
@@ -557,11 +567,15 @@ async fn test_resume_token_persistence_and_recovery() {
             let mut obj = HashMap::new();
             obj.insert(
                 "theme".to_string(),
-                Box::new(currentspace_capnweb_core::protocol::Value::String("dark".to_string())),
+                Box::new(currentspace_capnweb_core::protocol::Value::String(
+                    "dark".to_string(),
+                )),
             );
             obj.insert(
                 "language".to_string(),
-                Box::new(currentspace_capnweb_core::protocol::Value::String("en".to_string())),
+                Box::new(currentspace_capnweb_core::protocol::Value::String(
+                    "en".to_string(),
+                )),
             );
             obj
         }),
@@ -633,13 +647,15 @@ async fn test_nested_capability_lifecycle() {
             let mut obj = HashMap::new();
             obj.insert(
                 "precision".to_string(),
-                Box::new(currentspace_capnweb_core::protocol::Value::Number(Number::from(
-                    precision,
-                ))),
+                Box::new(currentspace_capnweb_core::protocol::Value::Number(
+                    Number::from(precision),
+                )),
             );
             obj.insert(
                 "name".to_string(),
-                Box::new(currentspace_capnweb_core::protocol::Value::String(name.to_string())),
+                Box::new(currentspace_capnweb_core::protocol::Value::String(
+                    name.to_string(),
+                )),
             );
             obj
         });
@@ -809,7 +825,8 @@ async fn test_il_plan_runner_edge_cases() {
     println!("✅ Complex nested structure execution successful");
 
     // Test 4: Plan complexity analysis
-    let complexity = currentspace_capnweb_core::protocol::PlanOptimizer::analyze_complexity(&complex_plan);
+    let complexity =
+        currentspace_capnweb_core::protocol::PlanOptimizer::analyze_complexity(&complex_plan);
     println!("✅ Complex plan analysis: {:?}", complexity);
     assert!(
         complexity.total_operations >= 5,

--- a/capnweb-core/tests/advanced_features_integration.rs
+++ b/capnweb-core/tests/advanced_features_integration.rs
@@ -2,7 +2,7 @@
 // Tests Resume Tokens, Nested Capabilities, Advanced IL Plan Runner, and transport integration
 
 use async_trait::async_trait;
-use capnweb_core::{
+use currentspace_capnweb_core::{
     il::{Op, Plan, Source},
     protocol::{
         tables::Value, CapabilityFactory, CapabilityGraph, CapabilityMetadata,
@@ -63,9 +63,9 @@ impl RpcTarget for AdvancedCalculatorCapability {
     async fn call(
         &self,
         method: &str,
-        args: Vec<capnweb_core::protocol::Value>,
-    ) -> Result<capnweb_core::protocol::Value, RpcError> {
-        use capnweb_core::protocol::Value;
+        args: Vec<currentspace_capnweb_core::protocol::Value>,
+    ) -> Result<currentspace_capnweb_core::protocol::Value, RpcError> {
+        use currentspace_capnweb_core::protocol::Value;
 
         match method {
             "add" => {
@@ -132,8 +132,8 @@ impl RpcTarget for AdvancedCalculatorCapability {
     async fn get_property(
         &self,
         property: &str,
-    ) -> Result<capnweb_core::protocol::Value, RpcError> {
-        use capnweb_core::protocol::Value;
+    ) -> Result<currentspace_capnweb_core::protocol::Value, RpcError> {
+        use currentspace_capnweb_core::protocol::Value;
 
         match property {
             "precision" => Ok(Value::Number(Number::from(self.precision))),
@@ -155,9 +155,9 @@ impl CapabilityFactory for CalculatorFactory {
     async fn create_capability(
         &self,
         capability_type: &str,
-        config: capnweb_core::protocol::Value,
-    ) -> Result<Arc<dyn RpcTarget>, capnweb_core::protocol::CapabilityError> {
-        use capnweb_core::protocol::{CapabilityError, Value};
+        config: currentspace_capnweb_core::protocol::Value,
+    ) -> Result<Arc<dyn RpcTarget>, currentspace_capnweb_core::protocol::CapabilityError> {
+        use currentspace_capnweb_core::protocol::{CapabilityError, Value};
 
         match capability_type {
             "calculator" => {
@@ -250,11 +250,11 @@ impl CapabilityFactory for CalculatorFactory {
                         return_type: "array".to_string(),
                     },
                 ],
-                config_schema: Some(capnweb_core::protocol::Value::Object({
+                config_schema: Some(currentspace_capnweb_core::protocol::Value::Object({
                     let mut schema = HashMap::new();
                     schema.insert(
                         "precision".to_string(),
-                        Box::new(capnweb_core::protocol::Value::String("number".to_string())),
+                        Box::new(currentspace_capnweb_core::protocol::Value::String("number".to_string())),
                     );
                     schema
                 })),
@@ -334,11 +334,11 @@ async fn test_comprehensive_advanced_features_integration() {
     println!("✅ Available capability types: {:?}", types.unwrap());
 
     // Create a sub-capability
-    let config = capnweb_core::protocol::Value::Object({
+    let config = currentspace_capnweb_core::protocol::Value::Object({
         let mut obj = HashMap::new();
         obj.insert(
             "precision".to_string(),
-            Box::new(capnweb_core::protocol::Value::Number(Number::from(4))),
+            Box::new(currentspace_capnweb_core::protocol::Value::Number(Number::from(4))),
         );
         obj
     });
@@ -423,14 +423,14 @@ async fn test_comprehensive_advanced_features_integration() {
 
     // Verify the result structure
     match result {
-        capnweb_core::protocol::Value::Object(obj) => {
+        currentspace_capnweb_core::protocol::Value::Object(obj) => {
             assert!(obj.contains_key("add_result"), "Missing add_result");
             assert!(obj.contains_key("final_result"), "Missing final_result");
             assert!(obj.contains_key("operation"), "Missing operation");
 
             // Verify the calculation: (5 + 3) * 2 = 16
             if let Some(boxed_final) = obj.get("final_result") {
-                if let capnweb_core::protocol::Value::Number(n) = boxed_final.as_ref() {
+                if let currentspace_capnweb_core::protocol::Value::Number(n) = boxed_final.as_ref() {
                     assert_eq!(n.as_f64(), Some(16.0), "Calculation result should be 16");
                     println!("✅ Calculation result verified: {}", n);
                 }
@@ -442,7 +442,7 @@ async fn test_comprehensive_advanced_features_integration() {
     // 4. Test Plan Complexity Analysis
     println!("\n📊 Testing Plan Complexity Analysis...");
 
-    let complexity = capnweb_core::protocol::PlanOptimizer::analyze_complexity(&plan);
+    let complexity = currentspace_capnweb_core::protocol::PlanOptimizer::analyze_complexity(&plan);
     println!("✅ Plan complexity: {:?}", complexity);
 
     assert!(complexity.total_operations > 0, "Should have operations");
@@ -475,8 +475,8 @@ async fn test_comprehensive_advanced_features_integration() {
         .call(
             "add",
             vec![
-                capnweb_core::protocol::Value::Number(Number::from(10)),
-                capnweb_core::protocol::Value::Number(Number::from(5)),
+                currentspace_capnweb_core::protocol::Value::Number(Number::from(10)),
+                currentspace_capnweb_core::protocol::Value::Number(Number::from(5)),
             ],
         )
         .await;
@@ -485,11 +485,11 @@ async fn test_comprehensive_advanced_features_integration() {
     println!("✅ Base calculation: 10 + 5 = {:?}", base_result.unwrap());
 
     // Create sub-capability through nested interface
-    let sub_config = capnweb_core::protocol::Value::Object({
+    let sub_config = currentspace_capnweb_core::protocol::Value::Object({
         let mut obj = HashMap::new();
         obj.insert(
             "precision".to_string(),
-            Box::new(capnweb_core::protocol::Value::Number(Number::from(6))),
+            Box::new(currentspace_capnweb_core::protocol::Value::Number(Number::from(6))),
         );
         obj
     });
@@ -527,7 +527,7 @@ async fn test_comprehensive_advanced_features_integration() {
 
     // Test capability factory error handling
     let bad_capability = factory
-        .create_capability("nonexistent", capnweb_core::protocol::Value::Null)
+        .create_capability("nonexistent", currentspace_capnweb_core::protocol::Value::Null)
         .await;
     assert!(
         bad_capability.is_err(),
@@ -549,25 +549,25 @@ async fn test_resume_token_persistence_and_recovery() {
     let mut variables = HashMap::new();
     variables.insert(
         "user_id".to_string(),
-        capnweb_core::protocol::Value::Number(Number::from(12345)),
+        currentspace_capnweb_core::protocol::Value::Number(Number::from(12345)),
     );
     variables.insert(
         "session_data".to_string(),
-        capnweb_core::protocol::Value::Object({
+        currentspace_capnweb_core::protocol::Value::Object({
             let mut obj = HashMap::new();
             obj.insert(
                 "theme".to_string(),
-                Box::new(capnweb_core::protocol::Value::String("dark".to_string())),
+                Box::new(currentspace_capnweb_core::protocol::Value::String("dark".to_string())),
             );
             obj.insert(
                 "language".to_string(),
-                Box::new(capnweb_core::protocol::Value::String("en".to_string())),
+                Box::new(currentspace_capnweb_core::protocol::Value::String("en".to_string())),
             );
             obj
         }),
     );
 
-    let snapshot = capnweb_core::protocol::SessionSnapshot {
+    let snapshot = currentspace_capnweb_core::protocol::SessionSnapshot {
         session_id: "persistence-test".to_string(),
         created_at: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -629,17 +629,17 @@ async fn test_nested_capability_lifecycle() {
     let mut created_ids = Vec::new();
 
     for (name, precision) in configs {
-        let config = capnweb_core::protocol::Value::Object({
+        let config = currentspace_capnweb_core::protocol::Value::Object({
             let mut obj = HashMap::new();
             obj.insert(
                 "precision".to_string(),
-                Box::new(capnweb_core::protocol::Value::Number(Number::from(
+                Box::new(currentspace_capnweb_core::protocol::Value::Number(Number::from(
                     precision,
                 ))),
             );
             obj.insert(
                 "name".to_string(),
-                Box::new(capnweb_core::protocol::Value::String(name.to_string())),
+                Box::new(currentspace_capnweb_core::protocol::Value::String(name.to_string())),
             );
             obj
         });
@@ -650,9 +650,9 @@ async fn test_nested_capability_lifecycle() {
             .unwrap();
 
         // Extract capability ID
-        if let capnweb_core::protocol::Value::Object(obj) = result {
+        if let currentspace_capnweb_core::protocol::Value::Object(obj) = result {
             if let Some(boxed_id) = obj.get("capability_id") {
-                if let capnweb_core::protocol::Value::String(id) = boxed_id.as_ref() {
+                if let currentspace_capnweb_core::protocol::Value::String(id) = boxed_id.as_ref() {
                     created_ids.push(id.clone());
                     println!(
                         "✅ Created capability: {} with precision {}",
@@ -673,7 +673,7 @@ async fn test_nested_capability_lifecycle() {
 
     // List all child capabilities
     let children = nested_target.list_child_capabilities().await.unwrap();
-    if let capnweb_core::protocol::Value::Array(child_array) = children {
+    if let currentspace_capnweb_core::protocol::Value::Array(child_array) = children {
         assert_eq!(child_array.len(), 3);
         println!("✅ Listed {} child capabilities", child_array.len());
     }
@@ -684,7 +684,7 @@ async fn test_nested_capability_lifecycle() {
             .dispose_child_capability(id_to_dispose)
             .await
             .unwrap();
-        if let capnweb_core::protocol::Value::Bool(true) = dispose_result {
+        if let currentspace_capnweb_core::protocol::Value::Bool(true) = dispose_result {
             println!("✅ Successfully disposed capability: {}", id_to_dispose);
         }
     }
@@ -755,7 +755,7 @@ async fn test_il_plan_runner_edge_cases() {
         "Parameter-based plan should execute"
     );
 
-    if let Ok(capnweb_core::protocol::Value::Number(n)) = param_execution {
+    if let Ok(currentspace_capnweb_core::protocol::Value::Number(n)) = param_execution {
         assert_eq!(n.as_f64(), Some(40.0), "15 + 25 should equal 40");
         println!("✅ Parameter access: 15 + 25 = {}", n);
     }
@@ -809,7 +809,7 @@ async fn test_il_plan_runner_edge_cases() {
     println!("✅ Complex nested structure execution successful");
 
     // Test 4: Plan complexity analysis
-    let complexity = capnweb_core::protocol::PlanOptimizer::analyze_complexity(&complex_plan);
+    let complexity = currentspace_capnweb_core::protocol::PlanOptimizer::analyze_complexity(&complex_plan);
     println!("✅ Complex plan analysis: {:?}", complexity);
     assert!(
         complexity.total_operations >= 5,

--- a/capnweb-interop-tests/Cargo.toml
+++ b/capnweb-interop-tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "capnweb-interop-tests"
+name = "currentspace-capnweb-interop-tests"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -9,10 +9,10 @@ repository.workspace = true
 description = "Interoperability tests for Cap'n Web implementations"
 
 [dependencies]
-capnweb-core.workspace = true
-capnweb-transport.workspace = true
-capnweb-server.workspace = true
-capnweb-client.workspace = true
+currentspace-capnweb-core.workspace = true
+currentspace-capnweb-transport.workspace = true
+currentspace-capnweb-server.workspace = true
+currentspace-capnweb-client.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/capnweb-interop-tests/src/fixtures.rs
+++ b/capnweb-interop-tests/src/fixtures.rs
@@ -1,4 +1,4 @@
-use capnweb_core::{CallId, CapId, Message, Op, Outcome, Plan, Source, Target};
+use currentspace_capnweb_core::{CallId, CapId, Message, Op, Outcome, Plan, Source, Target};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 

--- a/capnweb-interop-tests/src/simple_interop.rs
+++ b/capnweb-interop-tests/src/simple_interop.rs
@@ -1,6 +1,6 @@
 //! Simplified interop tests focusing on JSON serialization compatibility
 
-use capnweb_core::{CallId, CapId, Message, Op, Outcome, Plan, Source, Target};
+use currentspace_capnweb_core::{CallId, CapId, Message, Op, Outcome, Plan, Source, Target};
 use serde_json::json;
 
 /// Test that Rust plans can be serialized to JSON in a JavaScript-compatible format
@@ -227,7 +227,7 @@ mod tests {
         let error_msg = Message::result(
             CallId::new(1),
             Outcome::Error {
-                error: capnweb_core::RpcError::bad_request("test error"),
+                error: currentspace_capnweb_core::RpcError::bad_request("test error"),
             },
         );
 

--- a/capnweb-server/Cargo.toml
+++ b/capnweb-server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "capnweb-server"
+name = "currentspace-capnweb-server"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -7,7 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation = "https://docs.rs/capnweb-server"
+documentation = "https://docs.rs/currentspace-capnweb-server"
 description = "Production-ready server for Cap'n Web RPC protocol with capability management"
 readme = "README.md"
 keywords.workspace = true
@@ -18,8 +18,8 @@ name = "capnweb-server"
 path = "src/bin/capnweb-server.rs"
 
 [dependencies]
-capnweb-core.workspace = true
-capnweb-transport.workspace = true
+currentspace-capnweb-core.workspace = true
+currentspace-capnweb-transport.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -65,7 +65,7 @@ tracing-subscriber.workspace = true
 
 [features]
 default = ["all-transports"]
-all-transports = ["capnweb-transport/default"]
+all-transports = ["currentspace-capnweb-transport/default"]
 h3-server = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:rustls", "dep:rcgen", "dep:http"]
 
 [package.metadata.docs.rs]

--- a/capnweb-server/src/advanced_capability.rs
+++ b/capnweb-server/src/advanced_capability.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::new_without_default)] // Legacy code, will be removed
 
 use async_trait::async_trait;
+use chrono::Utc;
 use currentspace_capnweb_core::{
     il::{ArrayOp, CallOp, CaptureRef, ObjectOp, ParamRef, ResultRef, ValueRef},
     protocol::{
@@ -20,7 +21,6 @@ use currentspace_capnweb_core::{
     },
     CapId, Op, Plan, RpcError, RpcTarget, Source, Value,
 };
-use chrono::Utc;
 use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/capnweb-server/src/advanced_capability.rs
+++ b/capnweb-server/src/advanced_capability.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::new_without_default)] // Legacy code, will be removed
 
 use async_trait::async_trait;
-use capnweb_core::{
+use currentspace_capnweb_core::{
     il::{ArrayOp, CallOp, CaptureRef, ObjectOp, ParamRef, ResultRef, ValueRef},
     protocol::{
         ids::IdAllocator,
@@ -958,7 +958,7 @@ impl RpcTarget for AdvancedCapability {
                 });
 
                 // Add to capability graph
-                use capnweb_core::protocol::nested_capabilities::CapabilityNode;
+                use currentspace_capnweb_core::protocol::nested_capabilities::CapabilityNode;
                 let node = CapabilityNode {
                     id: cap_name.clone(),
                     capability_type: cap_type.to_string(),
@@ -1488,7 +1488,7 @@ mod tests {
             "operations": []
         });
 
-        // Convert serde_json::Value to capnweb_core::Value
+        // Convert serde_json::Value to currentspace_capnweb_core::Value
         fn json_value_to_core_value(json_val: serde_json::Value) -> Value {
             match json_val {
                 serde_json::Value::Null => Value::Null,

--- a/capnweb-server/src/bin/capnweb-server.rs
+++ b/capnweb-server/src/bin/capnweb-server.rs
@@ -5,8 +5,8 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use capnweb_core::{CapId, RpcError};
-use capnweb_server::{RpcTarget, Server, ServerConfig};
+use currentspace_capnweb_core::{CapId, RpcError};
+use currentspace_capnweb_server::{RpcTarget, Server, ServerConfig};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use tracing::{error, info};

--- a/capnweb-server/src/bin/example-server.rs
+++ b/capnweb-server/src/bin/example-server.rs
@@ -6,8 +6,8 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use capnweb_core::{CapId, RpcError};
-use capnweb_server::{RpcTarget, Server, ServerConfig};
+use currentspace_capnweb_core::{CapId, RpcError};
+use currentspace_capnweb_server::{RpcTarget, Server, ServerConfig};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/capnweb-server/src/bin/typescript-interop-server.rs
+++ b/capnweb-server/src/bin/typescript-interop-server.rs
@@ -6,8 +6,8 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use capnweb_core::{CapId, RpcError};
-use capnweb_server::{RpcTarget, Server, ServerConfig};
+use currentspace_capnweb_core::{CapId, RpcError};
+use currentspace_capnweb_server::{RpcTarget, Server, ServerConfig};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};

--- a/capnweb-server/src/cap_table.rs
+++ b/capnweb-server/src/cap_table.rs
@@ -1,5 +1,5 @@
 use crate::RpcTarget;
-use capnweb_core::CapId;
+use currentspace_capnweb_core::CapId;
 use dashmap::DashMap;
 use std::sync::Arc;
 

--- a/capnweb-server/src/capnweb_server.rs
+++ b/capnweb-server/src/capnweb_server.rs
@@ -675,12 +675,13 @@ async fn process_message(
                     }
                     Err(e) => {
                         // Store error in import table
-                        let error_expr =
-                            Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
+                        let error_expr = Expression::Error(
+                            currentspace_capnweb_core::protocol::ErrorExpression {
                                 error_type: "EvalError".to_string(),
                                 message: e.to_string(),
                                 stack: None,
-                            });
+                            },
+                        );
 
                         let _ = session.imports.insert(
                             import_id,
@@ -719,11 +720,13 @@ async fn process_message(
                         {
                             Ok(Some(Message::Reject(
                                 ExportId(import_id.0),
-                                Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
-                                    error_type: error_type.clone(),
-                                    message: message.clone(),
-                                    stack: stack.clone(),
-                                }),
+                                Expression::Error(
+                                    currentspace_capnweb_core::protocol::ErrorExpression {
+                                        error_type: error_type.clone(),
+                                        message: message.clone(),
+                                        stack: stack.clone(),
+                                    },
+                                ),
                             )))
                         } else {
                             Ok(Some(Message::Resolve(
@@ -757,11 +760,13 @@ async fn process_message(
                         // Channel closed without sending
                         Ok(Some(Message::Reject(
                             import_id.to_export_id(),
-                            Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
-                                error_type: "ChannelError".to_string(),
-                                message: "Resolution channel closed".to_string(),
-                                stack: None,
-                            }),
+                            Expression::Error(
+                                currentspace_capnweb_core::protocol::ErrorExpression {
+                                    error_type: "ChannelError".to_string(),
+                                    message: "Resolution channel closed".to_string(),
+                                    stack: None,
+                                },
+                            ),
                         )))
                     }
                     Err(_) => {
@@ -769,11 +774,13 @@ async fn process_message(
                         session_state.pending_pulls.write().await.remove(&import_id);
                         Ok(Some(Message::Reject(
                             import_id.to_export_id(),
-                            Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
-                                error_type: "Timeout".to_string(),
-                                message: "Pull request timed out".to_string(),
-                                stack: None,
-                            }),
+                            Expression::Error(
+                                currentspace_capnweb_core::protocol::ErrorExpression {
+                                    error_type: "Timeout".to_string(),
+                                    message: "Pull request timed out".to_string(),
+                                    stack: None,
+                                },
+                            ),
                         )))
                     }
                 }
@@ -844,8 +851,9 @@ async fn evaluate_expression(
                 if let Some(main) = &state.main_capability {
                     // Extract method name from property path
                     if let Some(path) = &import.property_path {
-                        if let Some(currentspace_capnweb_core::protocol::LegacyPropertyKey::String(method)) =
-                            path.first()
+                        if let Some(
+                            currentspace_capnweb_core::protocol::LegacyPropertyKey::String(method),
+                        ) = path.first()
                         {
                             // Extract call arguments
                             let args = if let Some(args_expr) = &import.call_arguments {
@@ -874,8 +882,11 @@ async fn evaluate_expression(
                     ImportValue::Stub(stub_ref) => {
                         // Extract method name from property path
                         if let Some(path) = &pipeline.property_path {
-                            if let Some(currentspace_capnweb_core::protocol::LegacyPropertyKey::String(method)) =
-                                path.first()
+                            if let Some(
+                                currentspace_capnweb_core::protocol::LegacyPropertyKey::String(
+                                    method,
+                                ),
+                            ) = path.first()
                             {
                                 // Extract call arguments
                                 let args = if let Some(args_expr) = &pipeline.call_arguments {

--- a/capnweb-server/src/capnweb_server.rs
+++ b/capnweb-server/src/capnweb_server.rs
@@ -8,7 +8,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use capnweb_core::{
+use currentspace_capnweb_core::{
     protocol::{ExportId, Expression, ImportId, ImportValue, Message, RpcSession, Value},
     RpcTarget,
 };
@@ -492,7 +492,7 @@ async fn create_websocket_session(server_state: &ServerState, session_id: String
 
     // Set up main capability at import ID 0 like batch sessions do
     if let Some(main_cap) = &server_state.main_capability {
-        use capnweb_core::protocol::tables::StubReference;
+        use currentspace_capnweb_core::protocol::tables::StubReference;
         let stub_ref = StubReference::new(main_cap.clone());
         let _insert_result = session
             .imports
@@ -617,7 +617,7 @@ async fn create_batch_session(state: &ServerState) -> SessionState {
 
     // Pre-allocate import ID 0 to the main capability
     if let Some(main_cap) = &state.main_capability {
-        use capnweb_core::protocol::tables::StubReference;
+        use currentspace_capnweb_core::protocol::tables::StubReference;
 
         let stub_ref = StubReference::new(main_cap.clone());
         let _ = session
@@ -676,7 +676,7 @@ async fn process_message(
                     Err(e) => {
                         // Store error in import table
                         let error_expr =
-                            Expression::Error(capnweb_core::protocol::ErrorExpression {
+                            Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
                                 error_type: "EvalError".to_string(),
                                 message: e.to_string(),
                                 stack: None,
@@ -719,7 +719,7 @@ async fn process_message(
                         {
                             Ok(Some(Message::Reject(
                                 ExportId(import_id.0),
-                                Expression::Error(capnweb_core::protocol::ErrorExpression {
+                                Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
                                     error_type: error_type.clone(),
                                     message: message.clone(),
                                     stack: stack.clone(),
@@ -757,7 +757,7 @@ async fn process_message(
                         // Channel closed without sending
                         Ok(Some(Message::Reject(
                             import_id.to_export_id(),
-                            Expression::Error(capnweb_core::protocol::ErrorExpression {
+                            Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
                                 error_type: "ChannelError".to_string(),
                                 message: "Resolution channel closed".to_string(),
                                 stack: None,
@@ -769,7 +769,7 @@ async fn process_message(
                         session_state.pending_pulls.write().await.remove(&import_id);
                         Ok(Some(Message::Reject(
                             import_id.to_export_id(),
-                            Expression::Error(capnweb_core::protocol::ErrorExpression {
+                            Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
                                 error_type: "Timeout".to_string(),
                                 message: "Pull request timed out".to_string(),
                                 stack: None,
@@ -844,7 +844,7 @@ async fn evaluate_expression(
                 if let Some(main) = &state.main_capability {
                     // Extract method name from property path
                     if let Some(path) = &import.property_path {
-                        if let Some(capnweb_core::protocol::LegacyPropertyKey::String(method)) =
+                        if let Some(currentspace_capnweb_core::protocol::LegacyPropertyKey::String(method)) =
                             path.first()
                         {
                             // Extract call arguments
@@ -874,7 +874,7 @@ async fn evaluate_expression(
                     ImportValue::Stub(stub_ref) => {
                         // Extract method name from property path
                         if let Some(path) = &pipeline.property_path {
-                            if let Some(capnweb_core::protocol::LegacyPropertyKey::String(method)) =
+                            if let Some(currentspace_capnweb_core::protocol::LegacyPropertyKey::String(method)) =
                                 path.first()
                             {
                                 // Extract call arguments
@@ -963,7 +963,7 @@ fn value_to_expression(value: Value) -> Expression {
             error_type,
             message,
             stack,
-        } => Expression::Error(capnweb_core::protocol::ErrorExpression {
+        } => Expression::Error(currentspace_capnweb_core::protocol::ErrorExpression {
             error_type: error_type.clone(),
             message: message.clone(),
             stack: stack.clone(),

--- a/capnweb-server/src/lib.rs
+++ b/capnweb-server/src/lib.rs
@@ -11,9 +11,9 @@
 //! ## Quick Start
 //!
 //! ```rust,ignore
-//! use capnweb_server::{Server, ServerConfig};
-//! use capnweb_core::{CapId, RpcError, Value};
-//! use capnweb_core::RpcTarget;  // Use RpcTarget from core, not server
+//! use currentspace_capnweb_server::{Server, ServerConfig};
+//! use currentspace_capnweb_core::{CapId, RpcError, Value};
+//! use currentspace_capnweb_core::RpcTarget;  // Use RpcTarget from core, not server
 //! use async_trait::async_trait;
 //! use std::sync::Arc;
 //! use serde_json::json;
@@ -64,8 +64,8 @@
 //! Register multiple capabilities with different IDs:
 //!
 //! ```rust,ignore
-//! # use capnweb_server::Server;
-//! # use capnweb_core::CapId;
+//! # use currentspace_capnweb_server::Server;
+//! # use currentspace_capnweb_core::CapId;
 //! # use std::sync::Arc;
 //! # struct AuthService;
 //! # struct DataService;

--- a/capnweb-server/src/lifecycle.rs
+++ b/capnweb-server/src/lifecycle.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use capnweb_core::{CapId, RpcError};
+use currentspace_capnweb_core::{CapId, RpcError};
 use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;

--- a/capnweb-server/src/promise_table.rs
+++ b/capnweb-server/src/promise_table.rs
@@ -1,4 +1,6 @@
-use currentspace_capnweb_core::{CallId, PendingPromise, PromiseDependencyGraph, PromiseId, RpcError};
+use currentspace_capnweb_core::{
+    CallId, PendingPromise, PromiseDependencyGraph, PromiseId, RpcError,
+};
 use dashmap::DashMap;
 use serde_json::Value;
 use std::collections::HashSet;

--- a/capnweb-server/src/promise_table.rs
+++ b/capnweb-server/src/promise_table.rs
@@ -1,4 +1,4 @@
-use capnweb_core::{CallId, PendingPromise, PromiseDependencyGraph, PromiseId, RpcError};
+use currentspace_capnweb_core::{CallId, PendingPromise, PromiseDependencyGraph, PromiseId, RpcError};
 use dashmap::DashMap;
 use serde_json::Value;
 use std::collections::HashSet;

--- a/capnweb-server/src/runner.rs
+++ b/capnweb-server/src/runner.rs
@@ -1,5 +1,5 @@
 use crate::{RpcTarget, ServerConfig};
-use capnweb_core::{CapId, Op, Plan, RpcError, Source};
+use currentspace_capnweb_core::{CapId, Op, Plan, RpcError, Source};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -169,7 +169,7 @@ impl PlanRunner {
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use capnweb_core::{Op, Plan, Source};
+    use currentspace_capnweb_core::{Op, Plan, Source};
 
     /// Test implementation of RpcTarget
     struct TestTarget {

--- a/capnweb-server/src/server.rs
+++ b/capnweb-server/src/server.rs
@@ -8,7 +8,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use capnweb_core::{
+use currentspace_capnweb_core::{
     parse_wire_batch, serialize_wire_batch, CapId, PropertyKey, RpcError, WireExpression,
     WireMessage,
 };

--- a/capnweb-server/src/server_wire_handler.rs
+++ b/capnweb-server/src/server_wire_handler.rs
@@ -1,7 +1,7 @@
 // Wire protocol handler for the server
 // This module adds wire protocol support to the existing server
 
-use capnweb_core::{PropertyKey, WireExpression};
+use currentspace_capnweb_core::{PropertyKey, WireExpression};
 use serde_json::Value;
 use std::collections::HashMap;
 use tracing::{debug, warn};

--- a/capnweb-server/src/wire_server.rs
+++ b/capnweb-server/src/wire_server.rs
@@ -10,7 +10,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use capnweb_core::{
+use currentspace_capnweb_core::{
     parse_wire_batch, serialize_wire_batch, PropertyKey, RpcError, WireExpression, WireMessage,
 };
 use dashmap::DashMap;

--- a/capnweb-server/src/ws_wire.rs
+++ b/capnweb-server/src/ws_wire.rs
@@ -7,7 +7,7 @@ use axum::{
     },
     response::Response,
 };
-use capnweb_core::{
+use currentspace_capnweb_core::{
     parse_wire_batch, serialize_wire_batch, CapId, PropertyKey, WireExpression, WireMessage,
 };
 use futures::{SinkExt, StreamExt};

--- a/capnweb-server/tests/integration_test.rs
+++ b/capnweb-server/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use capnweb_core::{CallId, CapId, Message, Outcome, RpcError, Target};
-use capnweb_server::{RpcTarget, Server, ServerConfig};
+use currentspace_capnweb_core::{CallId, CapId, Message, Outcome, RpcError, Target};
+use currentspace_capnweb_server::{RpcTarget, Server, ServerConfig};
 use serde_json::{json, Value};
 use std::sync::Arc;
 

--- a/capnweb-transport/Cargo.toml
+++ b/capnweb-transport/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "capnweb-transport"
+name = "currentspace-capnweb-transport"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -7,14 +7,14 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation = "https://docs.rs/capnweb-transport"
+documentation = "https://docs.rs/currentspace-capnweb-transport"
 description = "Transport layer implementations for Cap'n Web protocol (HTTP, WebSocket, WebTransport)"
 readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-capnweb-core.workspace = true
+currentspace-capnweb-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/capnweb-transport/src/capnweb_codec.rs
+++ b/capnweb-transport/src/capnweb_codec.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut, BytesMut};
-use capnweb_core::protocol::Message;
+use currentspace_capnweb_core::protocol::Message;
 use serde_json;
 use std::io;
 use tokio_util::codec::{Decoder, Encoder};
@@ -211,7 +211,7 @@ pub enum CodecError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use capnweb_core::{
+    use currentspace_capnweb_core::{
         protocol::{ExportId, ImportId},
         Expression,
     };

--- a/capnweb-transport/src/http3.rs
+++ b/capnweb-transport/src/http3.rs
@@ -3,7 +3,7 @@
 
 use crate::{RpcTransport, TransportError};
 use async_trait::async_trait;
-use capnweb_core::{decode_message, encode_message, Message};
+use currentspace_capnweb_core::{decode_message, encode_message, Message};
 use quinn::{Connection, Endpoint, RecvStream, SendStream};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/capnweb-transport/src/http_batch.rs
+++ b/capnweb-transport/src/http_batch.rs
@@ -1,6 +1,6 @@
 use crate::{RpcTransport, TransportError};
 use async_trait::async_trait;
-use capnweb_core::Message;
+use currentspace_capnweb_core::Message;
 use std::collections::VecDeque;
 
 /// HTTP Batch transport collects messages and sends them as a single HTTP request
@@ -86,7 +86,7 @@ impl RpcTransport for HttpBatchTransport {
 #[cfg(all(test, feature = "http-batch"))]
 mod tests {
     use super::*;
-    use capnweb_core::{CallId, CapId, Target};
+    use currentspace_capnweb_core::{CallId, CapId, Target};
     use serde_json::json;
 
     #[tokio::test]

--- a/capnweb-transport/src/negotiate.rs
+++ b/capnweb-transport/src/negotiate.rs
@@ -81,7 +81,7 @@ impl std::fmt::Debug for NegotiationResult {
 /// # Example
 ///
 /// ```no_run
-/// use capnweb_transport::negotiate::{negotiate, NegotiationConfig};
+/// use currentspace_capnweb_transport::negotiate::{negotiate, NegotiationConfig};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Use default negotiation (tries all transports)

--- a/capnweb-transport/src/transport.rs
+++ b/capnweb-transport/src/transport.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use bytes::Bytes;
-use capnweb_core::Message;
+use currentspace_capnweb_core::Message;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/capnweb-transport/src/websocket.rs
+++ b/capnweb-transport/src/websocket.rs
@@ -1,6 +1,6 @@
 use crate::{RpcTransport, TransportError};
 use async_trait::async_trait;
-use capnweb_core::{decode_message, encode_message, Message};
+use currentspace_capnweb_core::{decode_message, encode_message, Message};
 use futures::{SinkExt, StreamExt};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};

--- a/capnweb-transport/src/webtransport.rs
+++ b/capnweb-transport/src/webtransport.rs
@@ -2,7 +2,7 @@
 
 use crate::{RpcTransport, TransportError};
 use async_trait::async_trait;
-use capnweb_core::{decode_message, encode_message, Message};
+use currentspace_capnweb_core::{decode_message, encode_message, Message};
 use quinn::{Connection, Endpoint, RecvStream, SendStream};
 use std::sync::Arc;
 use tokio::sync::Mutex;

--- a/tests/validate_advanced_features.rs
+++ b/tests/validate_advanced_features.rs
@@ -1,7 +1,7 @@
 // Comprehensive End-to-End Validation of Cap'n Web Advanced Features
 // This test validates that all advanced features work correctly together
 
-use capnweb_core::{
+use currentspace_capnweb_core::{
     protocol::{
         // Resume Tokens
         ResumeTokenManager, PersistentSessionManager, SessionSnapshot,
@@ -15,7 +15,7 @@ use capnweb_core::{
     il::{Plan, Source},
     RpcTarget, RpcError, CapId,
 };
-use capnweb_transport::{
+use currentspace_capnweb_transport::{
     Http3Transport, Http3Config, Http3Stats,
     advanced::{Http3ConnectionPool, Http3LoadBalancer},
 };
@@ -98,7 +98,7 @@ impl AdvancedFeaturesValidator {
         assert_eq!(restored_id, "test-session-001", "Restored session ID mismatch");
 
         // Test expiration handling
-        let expired_token = capnweb_core::protocol::ResumeToken {
+        let expired_token = currentspace_capnweb_core::protocol::ResumeToken {
             token_data: token.token_data.clone(),
             session_id: token.session_id.clone(),
             expires_at: 0, // Already expired
@@ -461,7 +461,7 @@ impl CapabilityFactory for TestCapabilityFactory {
         vec!["test".to_string()]
     }
 
-    fn get_capability_metadata(&self, _capability_type: &str) -> Option<capnweb_core::protocol::CapabilityMetadata> {
+    fn get_capability_metadata(&self, _capability_type: &str) -> Option<currentspace_capnweb_core::protocol::CapabilityMetadata> {
         None
     }
 }

--- a/typescript-interop/test-array-escaping.mjs
+++ b/typescript-interop/test-array-escaping.mjs
@@ -1,0 +1,56 @@
+import { serialize, deserialize } from './capnweb-github/dist/index.js';
+
+console.log("Testing array escaping behavior:\n");
+
+// Test 1: Empty array
+try {
+  const empty = [];
+  const serialized = serialize(empty);
+  console.log("Empty array:", JSON.stringify(empty));
+  console.log("Serialized:", serialized);
+  console.log("Deserialized:", JSON.stringify(deserialize(serialized)));
+  console.log("✓ Empty array works\n");
+} catch (e) {
+  console.log("✗ Empty array failed:", e.message, "\n");
+}
+
+// Test 2: Array in object
+try {
+  const objWithArray = { items: [], count: 0 };
+  const serialized = serialize(objWithArray);
+  console.log("Object with empty array:", JSON.stringify(objWithArray));
+  console.log("Serialized:", serialized);
+  console.log("Deserialized:", JSON.stringify(deserialize(serialized)));
+  console.log("✓ Object with empty array works\n");
+} catch (e) {
+  console.log("✗ Object with empty array failed:", e.message, "\n");
+}
+
+// Test 3: Non-empty array
+try {
+  const arr = [1, 2, 3];
+  const serialized = serialize(arr);
+  console.log("Regular array:", JSON.stringify(arr));
+  console.log("Serialized:", serialized);
+  console.log("Deserialized:", JSON.stringify(deserialize(serialized)));
+  console.log("✓ Regular array works\n");
+} catch (e) {
+  console.log("✗ Regular array failed:", e.message, "\n");
+}
+
+// Test 4: Nested array in object
+try {
+  const nested = { data: { items: ["a", "b"] } };
+  const serialized = serialize(nested);
+  console.log("Nested array in object:", JSON.stringify(nested));
+  console.log("Serialized:", serialized);
+  console.log("Deserialized:", JSON.stringify(deserialize(serialized)));
+  console.log("✓ Nested array in object works\n");
+} catch (e) {
+  console.log("✗ Nested array in object failed:", e.message, "\n");
+}
+
+// Test 5: What SHOULD the wire format be for arrays in objects?
+console.log("\n=== Wire Format Analysis ===");
+console.log('Object {"items": [1,2]} serializes to:');
+console.log(serialize({items: [1, 2]}));

--- a/typescript-interop/test-edge-cases.mjs
+++ b/typescript-interop/test-edge-cases.mjs
@@ -1,0 +1,33 @@
+import { deserialize } from './capnweb-github/dist/index.js';
+
+console.log("Testing edge cases that might fail:\n");
+
+// Test what happens if we try to deserialize various formats directly
+
+const testCases = [
+  { name: "Bare empty array", json: '[]', expectError: true },
+  { name: "Escaped empty array", json: '[[]]', expectError: false },
+  { name: "Bare array [1,2]", json: '[1,2]', expectError: true },
+  { name: "Escaped array [[1,2]]", json: '[[1,2]]', expectError: false },
+  { name: "Object with bare empty array", json: '{"items": []}', expectError: true },
+  { name: "Object with escaped empty array", json: '{"items": [[]]}', expectError: false },
+  { name: "Single string array (ambiguous)", json: '["hello"]', expectError: true },
+  { name: "Escaped single string", json: '[["hello"]]', expectError: false },
+];
+
+for (const test of testCases) {
+  try {
+    const result = deserialize(test.json);
+    if (test.expectError) {
+      console.log(`✗ ${test.name}: Expected error but got: ${JSON.stringify(result)}`);
+    } else {
+      console.log(`✓ ${test.name}: ${JSON.stringify(result)}`);
+    }
+  } catch (e) {
+    if (test.expectError) {
+      console.log(`✓ ${test.name}: Correctly threw error: ${e.message}`);
+    } else {
+      console.log(`✗ ${test.name}: Unexpected error: ${e.message}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Renames all published crate names from `capnweb-*` to `currentspace-capnweb-*` to make it clear this is a third-party implementation and not an official Cloudflare implementation.

This addresses feedback from the Cap'n Web author at Cloudflare about avoiding namespace confusion on crates.io.

## Changes

### Crates Renamed (5 total)
- `capnweb-core` → `currentspace-capnweb-core`
- `capnweb-transport` → `currentspace-capnweb-transport`
- `capnweb-server` → `currentspace-capnweb-server`
- `capnweb-client` → `currentspace-capnweb-client`
- `capnweb-interop-tests` → `currentspace-capnweb-interop-tests`

### Files Updated
- ✅ All `Cargo.toml` files (workspace + 5 crates)
- ✅ All Rust source files (use statements and fully-qualified paths)
- ✅ `README.md` (crate names, badges, examples, documentation links)
- ✅ `CLAUDE.md` (project documentation)
- ✅ GitHub workflows (CI, release, docs, interop)

### What Stays the Same
- **Directory names**: Still `capnweb-core/`, `capnweb-server/`, etc.
- **Binary names**: Still `capnweb-server` (not `currentspace-capnweb-server`)
- **Module names**: Internal module structure unchanged

## Testing

- ✅ `cargo check --workspace` passes
- ✅ `cargo test --workspace` passes (176 tests)
- ✅ All unit tests passing
- ✅ Integration tests passing

## Follow-up Actions

After merge, the old crate names on crates.io will need to be deprecated (see PR description notes).

## Context

Related to HN discussion: https://news.ycombinator.com/item?id=45421221

The naming change makes it immediately clear this is currentspace's implementation of Cap'n Web, avoiding:
- Confusion with potential official Cloudflare crates
- Namespace squatting concerns
- Cap'n Proto naming confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed crates and updated import paths to currentspace-capnweb-* for consistent public package names.
- Documentation
  - Updated README, docs landing/links, examples, and release notes to the new crate names/URLs.
- Chores
  - Updated CI, release, and workspace configuration to reference the renamed packages.
- Tests
  - Updated test suites and examples to the new names; added TypeScript interop tests for arrays and edge cases.
- Notes
  - No functional or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->